### PR TITLE
extension requests blocked by CORS in vscode 1.68+, part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=2.2.1
+VERSION=2.2.2
 OUTPUT=_pkg
 .PHONY: build_linux build_macos pkg_linux pkg_macos all default clean setup docker test
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -174,7 +174,7 @@ func assetHandler(db *database.DB, assetURLPath string) http.Handler {
 
 		switch r.Method {
 		case http.MethodOptions:
-			w.Header().Set("Access-Control-Allow-Headers", "x-market-user-id,x-market-client-id")
+			w.Header().Set("Access-Control-Allow-Headers", r.Header.Get("Access-Control-Request-Headers"))
 		case http.MethodGet:
 			hlog.FromRequest(r).Debug().Msgf("extracting filename from path: %s", r.URL.Path)
 			// assemble filename from request URL

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -29,6 +29,27 @@ func TestCORSQuery(t *testing.T) {
 	}
 }
 
+func TestCORSAsset(t *testing.T) {
+	expectedHeaders := "test,hepp"
+
+	memdb, err := database.OpenMem()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodOptions, "https://www.foo.bar/testing", nil)
+	req.Header.Add("Access-Control-Request-Headers", expectedHeaders)
+	rec := httptest.NewRecorder()
+	handler := assetHandler(memdb, "https://www.foo.bar/testing")
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %v but got %v", http.StatusOK, rec.Code)
+	}
+	if rec.Header().Get("Access-Control-Allow-Headers") != expectedHeaders {
+		t.Fatalf("expected header 'Access-Control-Allow-Headers: %s' but got 'Access-Control-Allow-Headers: %s'", expectedHeaders, rec.Header().Get("Access-Control-Allow-Headers"))
+	}
+}
+
 func Test_URLParse(t *testing.T) {
 	type Test struct {
 		ExternalURL          string


### PR DESCRIPTION
Fixes #66